### PR TITLE
ci: remove redundant SSG build

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,7 +27,6 @@ jobs:
             ${{ runner.os }}-node
 
       - name: Install bun dependencies
-        if: steps.bun-cache.outputs.cache-hit != 'true'
         run: bun install --frozen-lockfile
 
       - name: Check format

--- a/.github/workflows/gh-page.yml
+++ b/.github/workflows/gh-page.yml
@@ -39,14 +39,10 @@ jobs:
             ${{ runner.os }}-node
 
       - name: Install bun dependencies
-        if: steps.bun-cache.outputs.cache-hit != 'true'
         run: bun install --frozen-lockfile
 
       - name: Build
         run: bun run build
-
-      - name: Build SSG
-        run: bun run build.server
 
       - name: Upload artifact
         uses: actions/upload-pages-artifact@v1


### PR DESCRIPTION
Include:
- Remove redundant SSG build in CD
- Remove cache check in CI/CD